### PR TITLE
QR code fix (service_relay)

### DIFF
--- a/handlers/user-qr.js
+++ b/handlers/user-qr.js
@@ -17,11 +17,14 @@ module.exports = {
    inputValidation: {},
 
    /**
-    * fn
-    * our Request handler.
+    * Initializes a mobile account and generates the registration QR code for
+    * the given user.
+    * 
+    * The QR code is delivered in a base64 data URL format.
+    * 
     * @param {obj} req
     *        the request object sent by the
-    *        api_sails/api/controllers/relay/user-qr-page.
+    *        api_sails/api/controllers/relay/user-qr.js page.
     * @param {fn} cb
     *        a node style callback(err, results) to send data when job is finished
     */
@@ -48,10 +51,11 @@ module.exports = {
             timeout: 8000,
          }).catch((err) => {
             req.log("Error posting registration token to MCC", err);
+            throw err;
          });
 
          const deepLink = getQRCodeData(req, registrationToken);
-         const qrCode = await getQRCodeImage(deepLink);
+         const qrCode = await getQRCodeDataURL(deepLink);
 
          cb(null, qrCode);
       } catch (e) {

--- a/handlers/user-qr.js
+++ b/handlers/user-qr.js
@@ -41,7 +41,7 @@ module.exports = {
          hasher.update(registrationToken);
          const hashedToken = hasher.digest("base64");
 
-         ABRelay.post({
+         await ABRelay.post({
             url: "/mcc/user",
             data: {
                user: siteUser,
@@ -50,8 +50,9 @@ module.exports = {
             },
             timeout: 8000,
          }).catch((err) => {
-            req.log("Error posting registration token to MCC", err);
-            throw err;
+            let message = "Error posting registration token to MCC";
+            req.log(message, err);
+            throw new Error(message);
          });
 
          const deepLink = getQRCodeData(req, registrationToken);

--- a/handlers/user-qr.js
+++ b/handlers/user-qr.js
@@ -51,7 +51,7 @@ module.exports = {
          });
 
          const deepLink = getQRCodeData(req, registrationToken);
-         const qrCode = await getQRCodeBase64(deepLink);
+         const qrCode = await getQRCodeImage(deepLink);
 
          cb(null, qrCode);
       } catch (e) {

--- a/utils/ABMobile.js
+++ b/utils/ABMobile.js
@@ -8,7 +8,6 @@
 const QRCode = require("qrcode");
 
 /**
- * getQRCodeData
  * return the string to be embedded as a QR code
  * @param {string} token the registration token of the user.
  * @return {string}
@@ -16,7 +15,7 @@ const QRCode = require("qrcode");
 function getQRCodeData(req, token) {
    let error;
    if (!token) {
-      error = new Error("Missing parameters to ABMobile.getQRCodeImage");
+      error = new Error("Missing parameters to ABMobile.getQRCodeData");
       error.code = "EMISSINGPARAMS";
       error.details = ["options.token"];
       req.log("ABMobile:getQRCodeData:Missing Data", {
@@ -39,12 +38,16 @@ function getQRCodeData(req, token) {
 }
 
 /**
- * getQRCodeImage
- * return a string with the encoded url data for the QR Code image.
+ * Return the QR Code image as a base64 PNG data URL.
+ * 
+ * A data URL means all the data for the image is found in the URL itself.
+ * The URL does not point to any location.
+ * See https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs
+ * 
  * @param {string} data  the data to encode in the QR Code.
  * @return {Promise}  resolved with {string} of QRCode Image.
  */
-function getQRCodeImage(data) {
+function getQRCodeDataURL(data) {
    return new Promise((resolve, reject) => {
       QRCode.toDataURL(data, { margin: 0 }, (err, image) => {
          if (err) reject(err);
@@ -56,13 +59,14 @@ function getQRCodeImage(data) {
 }
 
 /**
- * getQRCodeBase64
- * return the QRCodeImage in Base64 format
+ * Return the QRCodeImage as PNG binary file data.
+ * 
  * @param {string} data  the data to encode in the QR Code.
- * @return {Promise}  resolved with {Base64String} of QRCode Image.
+ * @return {Promise}  resolved with {Buffer} of the QRCode binary image.
  */
-function getQRCodeBase64(data) {
-   return getQRCodeImage(data).then((image) => {
+function getQRCodeImage(data) {
+   return getQRCodeDataURL(data).then((image) => {
+      // Convert the data URL into a binary image.
       var base64QR = image.substring(22);
       var qrcodeBuffer = Buffer.from(base64QR, "base64");
 
@@ -70,7 +74,7 @@ function getQRCodeBase64(data) {
    });
 }
 
-module.exports = { getQRCodeData, getQRCodeImage, getQRCodeBase64 };
+module.exports = { getQRCodeData, getQRCodeDataURL, getQRCodeImage };
 
 // These were from v1, not sure if we need in v2
 


### PR DESCRIPTION
The service was sending the QR code as a binary PNG image through Cote. I think Cote corrupted the data in transit. So this makes sure the data is sent as base64 text.

See https://github.com/digi-serve/ab_service_relay/issues/15 (Mobile app QR code does not display)