### PR TITLE
RSA_PKCS1_PADDING error fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "cote": "^1.0.2",
         "crypto": "^1.0.1",
         "lodash": "^4.17.21",
+        "node-rsa": "^1.1.1",
         "qrcode": "^1.5.0",
         "request-promise-native": "^1.0.9",
         "semver": "^7.6.0"
@@ -2964,7 +2965,6 @@
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
       "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "peer": true,
       "dependencies": {
         "safer-buffer": "~2.1.0"
       }
@@ -5404,6 +5404,14 @@
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="
     },
+    "node_modules/node-rsa": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-1.1.1.tgz",
+      "integrity": "sha512-Jd4cvbJMryN21r5HgxQOpMEqv+ooke/korixNNK3mGqfGJmy0M77WDDzo/05969+OkMy3XW1UuZsSmW9KQm7Fw==",
+      "dependencies": {
+        "asn1": "^0.2.4"
+      }
+    },
     "node_modules/nodemon": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.20.tgz",
@@ -6604,8 +6612,7 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "peer": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
       "version": "7.6.0",
@@ -9709,7 +9716,6 @@
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
       "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "peer": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -11577,6 +11583,14 @@
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="
     },
+    "node-rsa": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-1.1.1.tgz",
+      "integrity": "sha512-Jd4cvbJMryN21r5HgxQOpMEqv+ooke/korixNNK3mGqfGJmy0M77WDDzo/05969+OkMy3XW1UuZsSmW9KQm7Fw==",
+      "requires": {
+        "asn1": "^0.2.4"
+      }
+    },
     "nodemon": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.20.tgz",
@@ -12461,8 +12475,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "peer": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
       "version": "7.6.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "cote": "^1.0.2",
     "crypto": "^1.0.1",
     "lodash": "^4.17.21",
+    "node-rsa": "^1.1.1",
     "qrcode": "^1.5.0",
     "request-promise-native": "^1.0.9",
     "semver": "^7.6.0"


### PR DESCRIPTION
Seems like the crypto package that is now integrated into our browsers no longer support the `RSA_PKCS1_PADDING` option that we use in our key exchange.

We fixed the issue by importing a `node-rsa` package that still supports it.


## Release Notes
<!-- #release_notes -->
- [fix] Fix the recent RSA_PKCS1_PADDING error that was dropped for private usage
<!-- /release_notes --> 

## Test Status
No tests provided for this fix.
